### PR TITLE
[HOTFIX]: Disable randomization of background toggle

### DIFF
--- a/js/src/functions/functions.layout.js
+++ b/js/src/functions/functions.layout.js
@@ -59,7 +59,8 @@ function buildOptionLayout(key, option, $parent = null) {
     $optionToggleLabel = null,
     $optionToggleField = null,
     $optionToggleClassLabel = null,
-    $optionToggleClassField = null;
+    $optionToggleClassField = null,
+    $optionToggleIgnoreRandom = false;
 
   if ($parent === null) $parent = $(this);
 
@@ -86,6 +87,10 @@ function buildOptionLayout(key, option, $parent = null) {
         .attr("title", "Show")
         .attr("value", "")
         .on("change", buildFace);
+
+      if (option.hasOwnProperty("toggleIgnoreRandom") && option.toggleIgnoreRandom) {
+        $optionToggleField.data("ignore-random", "true");
+      }
 
       if (option.hasOwnProperty("hides")
         && typeof option.hides === "string"

--- a/js/src/functions/functions.layout.js
+++ b/js/src/functions/functions.layout.js
@@ -89,7 +89,7 @@ function buildOptionLayout(key, option, $parent = null) {
         .on("change", buildFace);
 
       if (option.hasOwnProperty("toggleIgnoreRandom") && option.toggleIgnoreRandom) {
-        $optionToggleField.data("ignore-random", "true");
+        $optionToggleField.data("ignore-random", true);
       }
 
       if (option.hasOwnProperty("hides")

--- a/js/src/functions/functions.options.js
+++ b/js/src/functions/functions.options.js
@@ -167,3 +167,16 @@ function classToggleOption(obj, toggleClass, toggleLabel, toggleLabelSuffix = ":
 
   return returnObject;
 }
+
+function toggleIgnoreRandomOption(obj) {
+  var returnObject = null;
+
+  obj = (typeof obj === "object") ? obj : null;
+
+  if (obj !== null) {
+    obj.toggleIgnoreRandom = true;
+    returnObject = obj;
+  }
+
+  return returnObject;
+}

--- a/js/src/functions/functions.randomFaces.js
+++ b/js/src/functions/functions.randomFaces.js
@@ -12,7 +12,7 @@ function randomSelectValue() {
 //Set a random checkbox value
 function randomCheckValue() {
   var $this = $(this)
-  if (!$this.hasData('ignore-random') || $this.data('ignore-random') !== 'true') {
+  if (typeof $this.data('ignore-random') === 'undefined' || $this.data('ignore-random') != true) {
     $this.attr('checked', (Math.random() >= 0.5) ? true : false);
   } else { $this.attr('checked', true); }
 }

--- a/js/src/functions/functions.randomFaces.js
+++ b/js/src/functions/functions.randomFaces.js
@@ -14,7 +14,7 @@ function randomCheckValue() {
   var $this = $(this)
   if (!$this.hasData('ignore-random') || $this.data('ignore-random') !== 'true') {
     $this.attr('checked', (Math.random() >= 0.5) ? true : false);
-  }
+  } else { $this.attr('checked', true); }
 }
 
 // Make a random face.

--- a/js/src/functions/functions.randomFaces.js
+++ b/js/src/functions/functions.randomFaces.js
@@ -12,7 +12,9 @@ function randomSelectValue() {
 //Set a random checkbox value
 function randomCheckValue() {
   var $this = $(this)
-  $this.attr('checked', (Math.random() >= 0.5) ? true : false);
+  if (!$this.hasData('ignore-random') || $this.data('ignore-random') !== 'true') {
+    $this.attr('checked', (Math.random() >= 0.5) ? true : false);
+  }
 }
 
 // Make a random face.

--- a/js/src/options/options.face.js
+++ b/js/src/options/options.face.js
@@ -32,7 +32,7 @@ var sections = {
   decoration: {
     label: "Decoration",
     options: {
-      bg: classToggleOption(toggleOption("Background", 9), "square", "Square")
+      bg: toggleIgnoreRandomOption(classToggleOption(toggleOption("Background", 9), "square", "Square"))
     }
   }
 };


### PR DESCRIPTION
## Description

Background toggler can no longer be random. Defaults to shown.

## Type of Change

<!-- Place an X inside the brackets of the relevant ones, please delete the irrelevant ones.  -->

- [X] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :art: UI Change
- [ ] :racehorse: Performance Enhancement
- [ ] :zap: General Update
- [ ] :lock: Security Update
- [ ] :ok_hand: Code Review Update
- [ ] :hammer: Code Refactor
- [ ] :bar_chart: Add/Update Analytics
- [ ] :books: Add/Update Documentation
- [ ] :bulb: Add/Update Source Code Documentation
- [ ] :wrench: Add/Update Configuration File(s)
- [X] :ambulance: **This addresses a critical issue (hotfix)**

## Addresses Issue(s)

N/A

## Proposed Release Notes

- Disable randomization of background toggle
